### PR TITLE
Fix for read registers response. Update to devices to fix HA error

### DIFF
--- a/custom_components/modbus_local_gateway/devices/MIC-2500TL-X.yaml
+++ b/custom_components/modbus_local_gateway/devices/MIC-2500TL-X.yaml
@@ -253,6 +253,7 @@ entities:
     precision: 2
     size: 2
     multiplier: 0.1
+    state_class: total
   EacTotal:
     title: Total generate energy
     address: 3051

--- a/custom_components/modbus_local_gateway/devices/MIN-6000TL-XH.yaml
+++ b/custom_components/modbus_local_gateway/devices/MIN-6000TL-XH.yaml
@@ -299,6 +299,7 @@ entities:
     precision: 2
     size: 2
     multiplier: 0.1
+    state_class: total
   EacTotal:
     title: Total generate energy
     address: 3051

--- a/custom_components/modbus_local_gateway/devices/MOD-6000TL-X.yaml
+++ b/custom_components/modbus_local_gateway/devices/MOD-6000TL-X.yaml
@@ -299,6 +299,7 @@ entities:
     precision: 2
     size: 2
     multiplier: 0.1
+    state_class: total
   EacTotal:
     title: Total generate energy
     address: 3051

--- a/custom_components/modbus_local_gateway/tcp_client.py
+++ b/custom_components/modbus_local_gateway/tcp_client.py
@@ -10,6 +10,7 @@ from pymodbus.client import AsyncModbusTcpClient
 from pymodbus.exceptions import ModbusException
 from pymodbus.framer import FramerType
 from pymodbus.pdu.pdu import ModbusPDU
+from pymodbus.pdu.register_read_message import ReadRegistersResponseBase
 
 from .context import ModbusContext
 

--- a/custom_components/modbus_local_gateway/tcp_client.py
+++ b/custom_components/modbus_local_gateway/tcp_client.py
@@ -133,6 +133,7 @@ class AsyncModbusTcpClientGateway(AsyncModbusTcpClient):
 
                     if (
                         modbus_response
+                        and isinstance(modbus_response, ReadRegistersResponseBase)
                         and len(modbus_response.registers) == entity.desc.register_count
                     ):
                         data[entity.desc.key] = modbus_response


### PR DESCRIPTION
Bugfixes:
- Handle case when read registers returns an execption response class.
- Update devices to set state class to total for resettable enitities

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `state_class` property to various energy-related entities in device configuration files.

- **Bug Fixes**
  - Enhanced type checking in Modbus TCP client to improve error handling and prevent potential runtime errors.

- **Chores**
  - Updated configuration files for MIC-2500TL-X, MIN-6000TL-XH, and MOD-6000TL-X devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->