### PR TITLE
Rename 'native_unit_of_measurement' to 'unit_of_measurement' for consistency

### DIFF
--- a/custom_components/modbus_local_gateway/entity_management/modbus_device_info.py
+++ b/custom_components/modbus_local_gateway/entity_management/modbus_device_info.py
@@ -182,7 +182,7 @@ class ModbusDeviceInfo:
             state_class = None
 
         return {
-            "native_unit_of_measurement": unit,
+            "unit_of_measurement": unit,
             "device_class": device_class,
             "state_class": state_class,
         }
@@ -245,7 +245,7 @@ class ModbusDeviceInfo:
                 "is_string": _data.get(IS_STRING, False),
                 "is_signed": _data.get(IS_SIGNED, False),
                 "never_resets": _data.get(NEVER_RESETS, False),
-                "native_unit_of_measurement": uom["native_unit_of_measurement"],
+                "unit_of_measurement": uom["unit_of_measurement"],
                 "device_class": uom["device_class"],
                 "state_class": uom["state_class"],
                 "max_change": _data.get(MAX_CHANGE),

--- a/tests/test_modbus_device_info.py
+++ b/tests/test_modbus_device_info.py
@@ -242,7 +242,7 @@ def test_entity_create_all_fields() -> None:
         assert entity.conv_map == {1: "One"}
         assert entity.state_class == "total"
         assert entity.device_class == "A"
-        assert entity.native_unit_of_measurement == "%"
+        assert entity.unit_of_measurement == "%"
         assert entity.conv_flags == {1: "One"}
         assert entity.data_type == ModbusDataType.HOLDING_REGISTER
 


### PR DESCRIPTION
Standardize the naming of the unit of measurement in ModbusDeviceInfo to improve clarity and consistency across the codebase.

Resolve #73