### PR TITLE
Fix typo in MyTransactionManager docstring and add async_unload_entry test for Modbus integration

### DIFF
--- a/custom_components/modbus_local_gateway/transaction.py
+++ b/custom_components/modbus_local_gateway/transaction.py
@@ -8,7 +8,7 @@ from pymodbus.transaction import TransactionManager
 
 
 class MyTransactionManager(TransactionManager):
-    """Custom Transaction Manager to supress exception logging"""
+    """Custom Transaction Manager to suppress exception logging"""
 
     def data_received(self, data: bytes) -> None:
         """Catch any protocol exceptions so they don't pollute the HA logs"""

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,14 +1,15 @@
 """Sensor tests"""
 
 # pylint: disable=unexpected-keyword-arg, protected-access
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
+import pytest
 from pytest_homeassistant_custom_component.common import (
     HomeAssistant,
     MockConfigEntry,
 )
 
-from custom_components.modbus_local_gateway import async_setup_entry
+from custom_components.modbus_local_gateway import async_setup_entry, async_unload_entry
 from custom_components.modbus_local_gateway.const import DOMAIN
 
 
@@ -31,3 +32,31 @@ async def test_setup_entry(hass: HomeAssistant) -> None:
         return_value=True,
     ):
         await async_setup_entry(hass, mock_config_entry)
+
+
+@pytest.mark.asyncio
+async def test_async_unload_entry(hass: HomeAssistant) -> None:
+    """Test the unload entry function."""
+    hass.data = {"modbus_local_gateway": {"localhost:123:1": "coordinator"}}  # type: ignore[assignment]
+
+    mock_config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": "localhost",
+            "port": 123,
+            "slave_id": 1,
+            "prefix": "test",
+            "filename": "test.yaml",
+            "name": "simple config",
+        },
+    )
+
+    with (
+        patch.object(
+            hass.config_entries, "async_unload_platforms", AsyncMock()
+        ) as unload_patch,
+    ):
+        result: bool = await async_unload_entry(hass, mock_config_entry)
+        assert result is True
+        unload_patch.assert_awaited_once()
+        assert "localhost:123:1" not in hass.data["modbus_local_gateway"]


### PR DESCRIPTION
Correct a typo in the MyTransactionManager docstring and introduce a test for the async_unload_entry function in the Modbus integration.