### PR TITLE
Potential fix for code scanning alert no. 20: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hassfest-validate.yml
+++ b/.github/workflows/hassfest-validate.yml
@@ -1,4 +1,6 @@
 name: Validate with hassfest
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/timlaing/modbus_local_gateway/security/code-scanning/20](https://github.com/timlaing/modbus_local_gateway/security/code-scanning/20)

To fix the problem, explicitly add a `permissions` block to the workflow to limit the GITHUB_TOKEN access, following the principle of least privilege. Since the shown workflow only checks out code and runs a Home Assistant community action (both of which only require read-only access), setting the permissions to `contents: read` is sufficient and recommended. This addition should appear at the root/workflow level (top-level, immediately after the `name:` and before `on:` blocks) unless finer granularity is desired at the job level. Only `.github/workflows/hassfest-validate.yml` needs to be updated, and no additional methods, imports, or variable definitions are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
