### PR TITLE
Potential fix for code scanning alert no. 21: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hacs-validate.yml
+++ b/.github/workflows/hacs-validate.yml
@@ -1,4 +1,6 @@
 name: Validate with HACS
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/timlaing/modbus_local_gateway/security/code-scanning/21](https://github.com/timlaing/modbus_local_gateway/security/code-scanning/21)

To fix this problem, you should specify a `permissions` block at either the workflow or job level to limit the default permissions of the `GITHUB_TOKEN`. The minimal starting point is `contents: read`, which allows only read access to code content and is usually sufficient for workflows that do not need to modify the repository. You should add this block near the top of the file, below the `name:` and before the `on:` block (for workflow-wide permissions), or inside the job as shown in the example. In this case, it is most maintainable to add it at the workflow level so that all jobs are covered.

No imports, additional methods, or variable changes are required—just a direct YAML block edit.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
