### PR TITLE
Potential fix for code scanning alert no. 24: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: Python tests
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/timlaing/modbus_local_gateway/security/code-scanning/24](https://github.com/timlaing/modbus_local_gateway/security/code-scanning/24)

To fix the problem, add a `permissions` block specifying the least privilege necessary for the job(s). Since this is a test workflow that only installs, tests, and uploads an artifact (but does not, for example, create releases or interact with issues/pull requests), it does not need any `write` permissions. The minimal required permission is `contents: read`. This block should be added at the workflow (top/root) level, right after the `name` and before `on:` (or before `jobs:` is also valid YAML). This solution does not change existing functionality but ensures best security practice for GITHUB_TOKEN usage.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
