### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,4 +1,6 @@
 name: SonarCloud scan
+permissions:
+  contents: read
 
 on:
   workflow_run:


### PR DESCRIPTION
Potential fix for [https://github.com/timlaing/modbus_local_gateway/security/code-scanning/10](https://github.com/timlaing/modbus_local_gateway/security/code-scanning/10)

To fix the problem, explicitly define the `permissions` key in the workflow, granting only the minimum necessary privileges (`contents: read`). This restricts the GITHUB_TOKEN used in the `sonar` job to read-only on repository contents, following the principle of least privilege and security best practices. Since the workflow is simple and involves only a single job, the cleanest approach is to add the permissions block at the root level, immediately after the `name:` (and before `on:`), applying to all jobs in the file. No changes to individual jobs, steps, imports, or secrets are required for this correction.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
