### PR TITLE
Potential fix for code scanning alert no. 22: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,4 +1,6 @@
 name: Linting
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/timlaing/modbus_local_gateway/security/code-scanning/22](https://github.com/timlaing/modbus_local_gateway/security/code-scanning/22)

The best way to fix this is to add a `permissions` block to the workflow file.  
- Place `permissions: contents: read` at the top level (right after `name: ...` and before `on:`) to apply to the entire workflow, ensuring no job will have unnecessary write access to repository contents or other resources, unless required and specified elsewhere.
- This follows the principle of least privilege and will not alter functionality since none of the steps shown require anything more than read-only access to repository contents.
- No changes to steps or additional imports are needed—just a single-line YAML addition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
