### PR TITLE
Don't fail the refresh when every entity has its own `scan_interval`

### DIFF
--- a/custom_components/modbus_local_gateway/coordinator.py
+++ b/custom_components/modbus_local_gateway/coordinator.py
@@ -282,10 +282,7 @@ class ModbusCoordinator(TimestampDataUpdateCoordinator):
         entities = [ctx for ctx in entities if ctx.desc.scan_interval is None]
         if not entities:
             # Every entity has its own scan_interval and polls on its own timer,
-            # so there is nothing for the shared refresh to fetch. That is not a
-            # failure: raising here would set last_update_success False and mark
-            # every entity unavailable, including the ones polling perfectly well
-            # on their own. Keep whatever those timers have already stored.
+            # so there is nothing for the shared refresh to fetch.
             _LOGGER.debug("No entities to refresh for %s", self.name)
             return self.data or {}
         data: dict[str, Any] = await self._update_device(entities=entities)

--- a/custom_components/modbus_local_gateway/coordinator.py
+++ b/custom_components/modbus_local_gateway/coordinator.py
@@ -280,6 +280,14 @@ class ModbusCoordinator(TimestampDataUpdateCoordinator):
             self.async_contexts(), key=lambda x: x.device_id
         )
         entities = [ctx for ctx in entities if ctx.desc.scan_interval is None]
+        if not entities:
+            # Every entity has its own scan_interval and polls on its own timer,
+            # so there is nothing for the shared refresh to fetch. That is not a
+            # failure: raising here would set last_update_success False and mark
+            # every entity unavailable, including the ones polling perfectly well
+            # on their own. Keep whatever those timers have already stored.
+            _LOGGER.debug("No entities to refresh for %s", self.name)
+            return self.data or {}
         data: dict[str, Any] = await self._update_device(entities=entities)
         if data:
             return data

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -658,3 +658,48 @@ async def test_async_update_entity(mock_config_entry: ConfigEntry) -> None:
     coordinator._update_device.return_value = {"test2": "value3"}
     await coordinator.async_update_entity(ctx2)
     assert coordinator.data == {"test1": "value1", "test2": "value3"}
+
+
+@pytest.mark.asyncio
+async def test_async_update_with_no_coordinator_entities(
+    mock_config_entry: ConfigEntry,
+) -> None:
+    """A device config where EVERY entity sets scan_interval must not fail.
+
+    async_update only polls entities without a scan_interval. If a config gives
+    one to all of them that list is empty, and raising here would set
+    last_update_success False and mark every entity unavailable - including the
+    ones their own timers are polling perfectly well.
+    """
+    client = MagicMock()
+    coordinator = ModbusCoordinator(
+        hass=MagicMock(),
+        config_entry=mock_config_entry,
+        gateway_device=MagicMock(),
+        client=client,
+        gateway="Test",
+    )
+
+    entities: list[ModbusContext] = [
+        ModbusContext(
+            1,
+            ModbusSensorEntityDescription(
+                register_address=1,
+                key="own_timer",
+                data_type=ModbusDataType.HOLDING_REGISTER,
+                scan_interval=10,
+            ),
+        )
+    ]
+    # what the entity's own timer already stored, via async_update_entity
+    coordinator.data = {"own_timer": 42}
+
+    with patch(
+        "custom_components.modbus_local_gateway.coordinator."
+        "ModbusCoordinator.async_contexts",
+        return_value=entities,
+    ):
+        result = await coordinator.async_update()
+
+    assert result == {"own_timer": 42}  # existing data preserved, not wiped
+    client.update_device.assert_not_called()  # nothing was polled


### PR DESCRIPTION
Hi! So this is my first PR here in a small series that will follow. The end goal is to add read-modify-write feature to this integration. I needed it to integrate my Midea-based heat pump.

I want to be upfront. I wrote the code with the assistance of Claude Code. I'm myself a programmer, so I tried to check all the PRs myself to the best of my capabilities and reduce the slop to minimum.

### Problem

`ModbusCoordinator.async_update()` raises `UpdateFailed` when the device returns no data. But the
coordinator only polls entities that have **no** `scan_interval` of their own — entities with one
are polled by their own timer.

So if every entity in a device config sets `scan_interval`, the coordinator's poll list is empty,
`update_device()` legitimately returns `{}`, and `UpdateFailed` is raised on **every refresh**. Home
Assistant then marks *all* the device's entities unavailable — including the ones whose own timers
are polling perfectly well.

The failure is confusing because the entities are being read successfully; only the coordinator's
own (empty) poll fails.

### Fix

Treat an empty poll list as "nothing to do" rather than an error: return the existing data
(`self.data or {}`) instead of raising.

An empty result from a *non-empty* poll list still raises, so a genuinely failing device is still
reported.

### Notes

Found on a device config where every entity had an explicit `scan_interval`; it cost a hardware test
run before the cause was clear. Tests cover both cases — empty poll list (no raise) and a real
failure (still raises).