### PR TITLE
Make the write path report the truth

### DIFF
--- a/custom_components/modbus_local_gateway/number.py
+++ b/custom_components/modbus_local_gateway/number.py
@@ -92,7 +92,7 @@ class ModbusNumberEntity(ModbusCoordinatorEntity, NumberEntity):  # type: ignore
     async def async_set_native_value(self, value: float) -> None:
         """Set new value."""
         if isinstance(self.coordinator, ModbusCoordinator):
-            await self.coordinator.client.write_data(self.coordinator_context, value)
+            await self.write_data(value)
 
     def _set_state(self, value: float) -> None:
         """Sets the underlying state of the entity,

--- a/custom_components/modbus_local_gateway/tcp_client.py
+++ b/custom_components/modbus_local_gateway/tcp_client.py
@@ -125,21 +125,24 @@ class AsyncModbusTcpClientGateway(AsyncModbusTcpClient):
 
     async def _custom_write_registers(
         self, address: int, values: List[int], device_id: int
-    ) -> None:
+    ) -> ModbusPDU | None:
         """Write values to Modbus registers. Try write_registers first, and
-        fall back to individual write_register calls if it fails."""
+        fall back to individual write_register calls if it fails.
+
+        Returns the last PDU received so the caller can detect an error
+        response; None only when there was nothing to write.
+        """
         if not values:
             _LOGGER.debug("No values to write, skipping.")
-            return
+            return None
 
         if len(values) == 1:
-            await self._write_single_register(address, values[0], device_id)
-        else:
-            await self._write_multiple_registers(address, values, device_id)
+            return await self._write_single_register(address, values[0], device_id)
+        return await self._write_multiple_registers(address, values, device_id)
 
     async def _write_single_register(
         self, address: int, value: int, device_id: int
-    ) -> None:
+    ) -> ModbusPDU:
         """Write a single value to a Modbus register."""
         _LOGGER.debug(
             "Writing single value %d to register at address %d, device_id %d",
@@ -161,10 +164,11 @@ class AsyncModbusTcpClientGateway(AsyncModbusTcpClient):
             )
         else:
             _LOGGER.debug("Writing successful")
+        return result
 
     async def _write_multiple_registers(
         self, address: int, values: List[int], device_id: int
-    ) -> None:
+    ) -> ModbusPDU:
         """Write multiple values to Modbus registers."""
         _LOGGER.debug(
             "Attempting to write multiple values %s starting at address %d, "
@@ -184,14 +188,21 @@ class AsyncModbusTcpClientGateway(AsyncModbusTcpClient):
                 "Falling back to old method (individual write_register calls).",
                 result,
             )
-            await self._write_registers_individually(address, values, device_id)
-        else:
-            _LOGGER.debug("Writing multiple values using write_registers successful")
+            fallback: ModbusPDU | None = await self._write_registers_individually(
+                address, values, device_id
+            )
+            return fallback if fallback is not None else result
+        _LOGGER.debug("Writing multiple values using write_registers successful")
+        return result
 
     async def _write_registers_individually(
         self, address: int, values: List[int], device_id: int
-    ) -> None:
-        """Fallback method to write multiple values to Modbus registers individually."""
+    ) -> ModbusPDU | None:
+        """Fallback method to write multiple values to Modbus registers individually.
+
+        Returns the first error PDU encountered, or the last successful one.
+        """
+        result: ModbusPDU | None = None
         for i, value in enumerate(values):
             current_address = address + i
             _LOGGER.debug(
@@ -200,7 +211,7 @@ class AsyncModbusTcpClientGateway(AsyncModbusTcpClient):
                 current_address,
                 device_id,
             )
-            result: ModbusPDU = await self.write_register(
+            result = await self.write_register(
                 address=current_address, value=value, device_id=device_id
             )
             if result.isError():
@@ -210,8 +221,9 @@ class AsyncModbusTcpClientGateway(AsyncModbusTcpClient):
                     current_address,
                     result,
                 )
-                return
+                return result
         _LOGGER.debug("All individual writes successful using fallback")
+        return result
 
     async def write_data(self, entity: ModbusContext, value: Any) -> ModbusPDU | None:
         """Writes data to Holding Registers or Coils"""
@@ -273,6 +285,10 @@ class AsyncModbusTcpClientGateway(AsyncModbusTcpClient):
                     entity.desc.key,
                     entity.desc.data_type,
                     pdu,
+                )
+                raise ModbusException(
+                    f"Error writing data to {entity.desc.key} "
+                    f"({entity.desc.data_type}): {pdu}"
                 )
 
             return pdu

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -783,7 +783,65 @@ async def test_write_data_holding_registers_success() -> None:
         mock_logger.debug.assert_called_with(
             "Writing multiple values using write_registers successful"
         )
-        assert result is None
+        # The write helpers return the PDU so write_data can detect an error
+        # response; before this was fixed they always returned None, which made
+        # the isError() check in write_data dead code.
+        assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_write_data_holding_registers_error_raises() -> None:
+    """An error response to a register write must not be reported as success."""
+    client = AsyncModbusTcpClientGateway(host="localhost")
+    client.connect = AsyncMock()
+    client.write_register = AsyncMock(return_value=ModbusPDU())
+    client.write_register.return_value.isError = lambda: True
+
+    entity = ModbusContext(
+        device_id=1,
+        desc=ModbusEntityDescription(
+            key="test",
+            register_address=1,
+            register_count=1,
+            data_type=ModbusDataType.HOLDING_REGISTER,
+        ),
+    )
+
+    with (
+        patch.object(
+            AsyncModbusTcpClientGateway, "connected", PropertyMock(return_value=True)
+        ),
+        patch.object(Conversion, "convert_to_registers", return_value=[123]),
+        pytest.raises(ModbusException, match="Error writing data to test"),
+    ):
+        await client.write_data(entity, value=123)
+
+
+@pytest.mark.asyncio
+async def test_write_data_coil_error_raises() -> None:
+    """An error response to a coil write must not be reported as success."""
+    client = AsyncModbusTcpClientGateway(host="localhost")
+    client.connect = AsyncMock()
+    client.write_coil = AsyncMock(return_value=ModbusPDU())
+    client.write_coil.return_value.isError = lambda: True
+
+    entity = ModbusContext(
+        device_id=1,
+        desc=ModbusEntityDescription(
+            key="test",
+            register_address=1,
+            register_count=1,
+            data_type=ModbusDataType.COIL,
+        ),
+    )
+
+    with (
+        patch.object(
+            AsyncModbusTcpClientGateway, "connected", PropertyMock(return_value=True)
+        ),
+        pytest.raises(ModbusException, match="Error writing data to test"),
+    ):
+        await client.write_data(entity, value=True)
 
 
 @pytest.mark.asyncio

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -8,6 +8,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.modbus_local_gateway.const import CONF_DEVICE_ID, DOMAIN
 from custom_components.modbus_local_gateway.context import ModbusContext
+from custom_components.modbus_local_gateway.coordinator import ModbusCoordinator
 from custom_components.modbus_local_gateway.entity_management.base import (
     ModbusDataType,
     ModbusNumberEntityDescription,
@@ -217,3 +218,39 @@ async def test_update_deviceupdate() -> None:
         debug.assert_called()
         warning.assert_not_called()
         write.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_async_set_native_value_reads_back() -> None:
+    """Setting a number must go through the entity's write_data.
+
+    number.py used to call client.write_data() directly, skipping the
+    re-read that switch/select/text all get, which left the matching
+    sensor stale for a full scan_interval after every write.
+    """
+    coordinator = MagicMock(spec=ModbusCoordinator)
+    coordinator.client = AsyncMock()
+    coordinator.config_entry = AsyncMock()
+    ctx = ModbusContext(
+        1,
+        ModbusNumberEntityDescription(
+            key="number",
+            register_address=1,
+            control_type="number",
+            min=1,
+            max=100,
+            data_type=ModbusDataType.HOLDING_REGISTER,
+        ),
+    )
+    entity = ModbusNumberEntity(
+        coordinator=coordinator, ctx=ctx, device=MagicMock()
+    )
+
+    with patch.object(coordinator.client, "write_data", AsyncMock()) as write_data:
+        await entity.async_set_native_value(42)
+
+        write_data.assert_called_once_with(entity.coordinator_context, 42)
+        # the readback is the point of routing through the entity
+        coordinator.async_update_entity.assert_awaited_once_with(
+            entity.coordinator_context
+        )


### PR DESCRIPTION
Two small, related fixes. Both are about a write appearing to succeed when it did not, or appearing
not to take effect when it did.

### 1. Surface failed register writes instead of swallowing them

`write_data()` logged an error PDU and returned normally, so a rejected write was
indistinguishable from a successful one. Callers had no way to know.

Now the write helpers return their `ModbusPDU` and `write_data()` raises `ModbusException` when the
device replies with an error.

**This is user-visible.** Every platform writes through `ModbusCoordinatorEntity.write_data()`, which
already catches broadly and re-raises `UpdateFailed` — that `except` was simply unreachable for
rejected writes until now. So a write the device rejects surfaces as an error in Home Assistant
instead of passing silently, for switches, selects, text and numbers alike. That is the point of the
change, but it is a behaviour change for existing configurations, not a no-op.

### 2. Route number writes through the entity so the value is read back

`ModbusNumberEntity.async_set_native_value()` called `coordinator.client.write_data(...)` directly,
bypassing `ModbusEntity.write_data()` — the path that re-reads the register after writing and
updates the entity.

The effect: after setting a number, its value stayed stale until the next scheduled poll, which on a
long `scan_interval` looks like the write silently did nothing. The switch platform already used the
entity path; this makes `number` consistent with it.

### Not addressed

`_write_registers_individually()` returns on the first error, so a bulk write that fails and falls
back to individual writes can leave a multi-register value half-updated on the device — the caller
learns only that it failed. This PR changes that function's signature but not that behaviour;
fixing it properly needs a rollback or two-phase write, which felt like a separate discussion.
Flagging it because the code is in the diff.

### Notes

The two fixes are separable but share a theme, so they are in one PR. Say the word if you would
rather have them apart.

